### PR TITLE
Arrondis à 1 chiffre après la virgule pour l'altitude

### DIFF
--- a/core/class/heliotrope.class.php
+++ b/core/class/heliotrope.class.php
@@ -348,7 +348,7 @@ class heliotrope extends eqLogic {
         }
 
         $this->checkAndUpdateCmd('azimuth360',round($azimuth360));
-        $this->checkAndUpdateCmd('altitude',round($altitude));
+        $this->checkAndUpdateCmd('altitude',round($altitude,1));
         $this->checkAndUpdateCmd('daystatus',$status);
         $this->checkAndUpdateCmd('daytext',$texte);
         log::add('heliotrope', 'debug', 'Statut ' . $status . ' ' . $texte . ' ' . round($azimuth360) . ' ' . round($altitude));


### PR DESCRIPTION
Bonjour lunarok,

héliotrope est paramétré chez moi pour une mise à jour des données toutes les 1 minute.

J'utilise principalement la donnée d'altitude pour fermer et ouvrir mes volets à la valeur -2,5°, cela permet le matin de profiter de la lumière avant le lever du soleil et le soir après le coucher.

L'arrondi à 1 chiffre après la virgule permet une meilleure réactivité de mon scénario car sinon on doit attendre le passage de l'entier -2° à -3° (et inversement) ce qui peut donner des retards de l'ordre d'une bonne dizaine de minutes sur mon scénario et ça se ressent !