### PR TITLE
Chemin icone du plugin

### DIFF
--- a/desktop/php/heliotrope.php
+++ b/desktop/php/heliotrope.php
@@ -38,7 +38,7 @@ $eqLogics = eqLogic::byType('heliotrope');
                 $opacity = ($eqLogic->getIsEnable()) ? '' : jeedom::getConfiguration('eqLogic:style:noactive');
                 echo '<div class="eqLogicDisplayCard cursor" data-eqLogic_id="' . $eqLogic->getId() . '" style="background-color : #ffffff ; height : 200px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;' . $opacity . '" >';
                 echo "<center>";
-                echo '<img src="plugins/heliotrope/doc/images/Heliotrope_icon.png" height="105" width="95" />';
+                echo '<img src="plugins/heliotrope/plugin_info/Heliotrope_icon.png" height="105" width="95" />';
                 echo "</center>";
                 echo '<span style="font-size : 1.1em;position:relative; top : 15px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;"><center>' . $eqLogic->getHumanName(true, true) . '</center></span>';
                 echo '</div>';


### PR DESCRIPTION
L'icone du plugin n'est plus dans doc/images mais dans plugin_info

Dans plugin_info, il y a 2 icones: Heliotrope_icon.png et heliotrope_icon.png
Seul le premier est appelé et uniquement dans desktop/php/heliotrope.php

A vous de choisir lequel conserver et de faire la modif en conséquence dans heliotrope.php