### PR TITLE
Corrections

### DIFF
--- a/core/class/heliotrope.class.php
+++ b/core/class/heliotrope.class.php
@@ -15,14 +15,14 @@
 * You should have received a copy of the GNU General Public License
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
-require_once dirname(__FILE__) . '/../../../../core/php/core.inc.php';
+require_once __DIR__ . '/../../../../core/php/core.inc.php';
 
 class heliotrope extends eqLogic {
     public static $_widgetPossibility = array('custom' => true);
 
     public static function pull() {
         foreach (eqLogic::byType('heliotrope', true) as $heliotrope) {
-                log::add('heliotrope', 'debug', 'info daily');
+                log::add(__CLASS__, 'debug', 'info daily');
                 $heliotrope->getInformations();
         }
     }
@@ -30,7 +30,7 @@ class heliotrope extends eqLogic {
     public static function cronHourly() {
         if (date('G')  == 3) {
             foreach (eqLogic::byType('heliotrope', true) as $heliotrope) {
-                    log::add('heliotrope', 'debug', 'info daily');
+                    log::add(__CLASS__, 'debug', 'info daily');
                     $heliotrope->getDaily();
                     $heliotrope->getInformations();
             }
@@ -39,7 +39,7 @@ class heliotrope extends eqLogic {
 
     public static function start() {
         foreach (eqLogic::byType('heliotrope', true) as $heliotrope) {
-                log::add('heliotrope', 'debug', 'info daily');
+                log::add(__CLASS__, 'debug', 'info daily');
                 $heliotrope->getDaily();
                 $heliotrope->getInformations();
         }
@@ -310,14 +310,22 @@ class heliotrope extends eqLogic {
         $altitude = $alt;
         //date_default_timezone_set("GMT");
 
-        $aubeast = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'aubeast')->execCmd();
-        $crepast = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'crepast')->execCmd();
-        $aubenau = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'aubenau')->execCmd();
-        $crepnau = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'crepnau')->execCmd();
-        $aubeciv = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'aubeciv')->execCmd();
-        $crepciv = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'crepciv')->execCmd();
-        $sunrise = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'sunrise')->execCmd();
-        $sunset = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'sunset')->execCmd();
+        $cmd = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'aubeast');
+        if(is_object($cmd)) $aubeast = $cmd->execCmd();
+        $cmd = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'crepast');
+        if(is_object($cmd)) $crepast = $cmd->execCmd();
+        $cmd = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'aubenau');
+        if(is_object($cmd)) $aubenau = $cmd->execCmd();
+        $cmd = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'crepnau');
+        if(is_object($cmd)) $crepnau = $cmd->execCmd();
+        $cmd = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'aubeciv');
+        if(is_object($cmd)) $aubeciv = $cmd->execCmd();
+        $cmd = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'crepciv');
+        if(is_object($cmd)) $crepciv = $cmd->execCmd();
+        $cmd = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'sunrise');
+        if(is_object($cmd)) $sunrise = $cmd->execCmd();
+        $cmd = heliotropeCmd::byEqLogicIdAndLogicalId($this->getId(),'sunset');
+        if(is_object($cmd)) $sunset = $cmd->execCmd();
 
         $actual =  date('Hi');
         if ($actual > $sunrise && $actual < $sunset) {
@@ -350,7 +358,7 @@ class heliotrope extends eqLogic {
         $this->checkAndUpdateCmd('altitude',round($altitude,1));
         $this->checkAndUpdateCmd('daystatus',$status);
         $this->checkAndUpdateCmd('daytext',$texte);
-        log::add('heliotrope', 'debug', 'Statut ' . $status . ' ' . $texte . ' ' . round($azimuth360) . ' ' . round($altitude));
+        log::add(__CLASS__, 'debug', 'Statut ' . $status . ' ' . $texte . ' ' . round($azimuth360) . ' ' . round($altitude));
         $this->refreshWidget();
     }
 
@@ -361,6 +369,7 @@ class heliotrope extends eqLogic {
         } else {
             $geotrav = eqLogic::byId($this->getConfiguration('geoloc'));
             if (!(is_object($geotrav) && $geotrav->getEqType_name() == 'geotrav')) {
+              log::add(__CLASS__, 'error', 'localisation invalide, veuillez sélectionner un équipement geotrav valide');
                 return;
             }
             $geolocval = geotravCmd::byEqLogicIdAndLogicalId($this->getConfiguration('geoloc'),'location:coordinate')->execCmd();
@@ -379,31 +388,31 @@ class heliotrope extends eqLogic {
         $now = new DateTime("now", $this_tz);
         $offset = $this_tz->getOffset($now) / 3600;
 
-        log::add('heliotrope', 'debug', 'Configuration : timezone ' . $timezone . ' offset ' . $offset);
-        log::add('heliotrope', 'debug', 'Configuration : latitude ' . $latitude . ' longitude ' . $longitude . ' zenith ' . $zenith);
+        log::add(__CLASS__, 'debug', 'Configuration : timezone ' . $timezone . ' offset ' . $offset);
+        log::add(__CLASS__, 'debug', 'Configuration : latitude ' . $latitude . ' longitude ' . $longitude . ' zenith ' . $zenith);
 
         $t = time();
-        $sunrisef = date_sunrise(time(), SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
+        $sunrisef = date_sunrise($t, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
         $sunrise = str_replace(':','',$sunrisef);
-        $sunsetf = date_sunset(time(), SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
+        $sunsetf = date_sunset($t, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
         $sunset = str_replace(':','',$sunsetf);
 
-        $zenith = $zenith + 6;
-        $aubecivf = date_sunrise(time(), SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
+        $zenith = 96;
+        $aubecivf = date_sunrise($t, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
         $aubeciv = str_replace(':','',$aubecivf);
-        $crepcivf = date_sunset(time(), SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
+        $crepcivf = date_sunset($t, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
         $crepciv = str_replace(':','',$crepcivf);
 
-        $zenith = $zenith + 6;
-        $aubenauf = date_sunrise(time(), SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
+        $zenith = 102;
+        $aubenauf = date_sunrise($t, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
         $aubenau = str_replace(':','',$aubenauf);
-        $crepnauf = date_sunset(time(), SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
+        $crepnauf = date_sunset($t, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
         $crepnau = str_replace(':','',$crepnauf);
 
-        $zenith = $zenith + 6;
-        $aubeastf = date_sunrise(time(), SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
+        $zenith = 108;
+        $aubeastf = date_sunrise($t, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
         $aubeast = str_replace(':','',$aubeastf);
-        $crepastf = date_sunset(time(), SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
+        $crepastf = date_sunset($t, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $offset);
         $crepast = str_replace(':','',$crepastf);
 
         $sunrisef = new DateTime($sunrisef);
@@ -416,7 +425,7 @@ class heliotrope extends eqLogic {
         $zenithf = date("H:i", $sun_info['transit']);
         $zenith = str_replace(':','',$zenithf);
 
-        log::add('heliotrope', 'info', 'getDaily');
+        log::add(__CLASS__, 'info', 'getDaily');
 
         $this->checkAndUpdateCmd('sunrise',$sunrise);
         $this->checkAndUpdateCmd('sunset',$sunset);
@@ -488,6 +497,14 @@ class heliotrope extends eqLogic {
         $replace['#altitude#'] = $value['altitude'];
         $replace['#sunrise#'] = substr_replace($value['sunrise'],':',-2,0);
         $replace['#sunset#'] = substr_replace($value['sunset'],':',-2,0);
+        $replace['#aubeciv#'] = substr_replace($value['aubeciv'],':',-2,0);
+        $replace['#crepciv#'] = substr_replace($value['crepciv'],':',-2,0);
+        $replace['#aubenau#'] = substr_replace($value['aubenau'],':',-2,0);
+        $replace['#crepnau#'] = substr_replace($value['crepnau'],':',-2,0);
+        $replace['#aubeast#'] = substr_replace($value['aubeast'],':',-2,0);
+        $replace['#crepast#'] = substr_replace($value['crepast'],':',-2,0);
+        $replace['#zenith#'] = substr_replace($value['zenith'],':',-2,0);
+        $replace['#daylen#'] = floor($value['daylen']/60) .'h ' .$value['daylen']%60 .'min';
 
         $replace['#collectDate#'] = $this->getStatus('lastCommunication', date('Y-m-d H:i:s'));
 
@@ -498,7 +515,9 @@ class heliotrope extends eqLogic {
             $replace['#heliosun#'] = "opacity : 0.3";
             $replace['#heliomoon#'] = "opacity : 1";
         }
-
+        if (file_exists( __DIR__ ."/../template/$_version/heliotrope_user.html"))
+          return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, 'heliotrope_user', 'heliotrope')));
+        else
         return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, 'heliotrope', 'heliotrope')));
     }
 

--- a/core/template/dashboard/heliotrope.html
+++ b/core/template/dashboard/heliotrope.html
@@ -1,15 +1,15 @@
 <div class="eqLogic-widget eqLogic allowResize" style="height: #height#;width: #width#;border:#border#;border-radius:#border-radius#;background-color: #background-color#;color: #color#;#style#" data-eqLogic_id="#id#" data-eqLogic_uid="#uid#" data-version="#version#" >
-	<center class="widget-name"><a href="#eqLink#" style="font-size : 1.5em;#hideEqLogicName#">#name_display#</a></center><br />
-	<div style="position : relative; left : 10px;">
-		<div class="pull-right" style="margin-right: 35px;margin-top: 5px;">
+	<center class="widget-name"><a href="#eqLink#" style="font-size : 1.5em;#hideEqLogicName#">#name_display#</a></center>
+	<div style="position : relative; left: 0px; margin-top: 10px;">
+		<div class="pull-right" style="margin-right: 15px;margin-top: 5px;">
 			<div id="azimuth#id#" style="width: 80px; height: 80px;" class="cmd noRefresh" data-type="info" data-subtype="numeric" data-cmd_id="#azimuth360_id#"></div>
 		</div>
 		<div class="pull-left" style="margin-left: 15px;margin-top: 5px;">
 			<div id="sunAlt#id#" style="width: 80px; height: 80px;" class="cmd noRefresh" data-type="info" data-subtype="numeric" data-cmd_id="#sunAlt_id#"></div>
-		</div><br/>
-		<div style="margin-top: 0px;">
-			<center style="left:0px;"><i style="#heliosun#;" class="far fa-sun"></i> | <i style="#heliomoon#;" class="far fa-moon"></i></center>
-			<center style="font-size: 1em; position: relative;left:3px;cursor:default;">#sunrise# | #sunset#</center>
+    </div><br/>
+		<div style="margin-left: 70px; margin-right: 100px; margin-top: 0px;">
+			<center><i style="#heliosun#;" class="far fa-sun fa-2x"></i> &nbsp; <i style="#heliomoon#;" class="far fa-moon fa-2x"></i></center>
+			<center style="font-size: 1em; position: relative;left:3px;cursor:default;">#sunrise# - #sunset#</center>
 		</div>
 	</div><br/>
 	<script>
@@ -49,16 +49,26 @@
 						dataLabels: {
 							enabled: false
 						}
-					}
+					},
+          gauge: {
+            dial: {
+              backgroundColor: 'red',
+              borderColor: 'red',
+            },
+            pivot: {
+              backgroundColor: 'silver'
+            }
+          }
 				},
 				yAxis: {
-					min: -90,
-					max: 90,
+					min: 0,
+					max: 360,
 					tickWidth: 2,
 					tickLength: 10,
-					tickInterval: 45,
+					tickInterval: 90,
 					lineWidth: 4,
 					labels: {
+            distance: -16,
 						formatter: function () {
 							if (this.value == 360) {
 								return '<span style="font-weight:bold;">N</span>';
@@ -102,7 +112,6 @@
 					credits: {
 						enabled: false
 					},
-
 					pane: {
 						startAngle: -180,
 						endAngle: 0,
@@ -116,17 +125,26 @@
 							dataLabels: {
 								enabled: false
 							}
-						}
+						},
+            gauge: {
+              dial: {
+                backgroundColor: 'red',
+                borderColor: 'red',
+              },
+              pivot: {
+                backgroundColor: 'silver'
+              }
+            }
 					},
 					yAxis: {
 						min: -90,
 						max: 90,
-
 						tickWidth: 2,
 						tickLength: 10,
-						tickInterval: 45,
+						tickInterval: 90,
 						lineWidth: 4,
 						labels: {
+              distance: -16,
 							formatter: function () {
 								if (this.value == 0) {
 									return '<span style="font-weight:bold;">0</span>';
@@ -144,12 +162,10 @@
 						title: {
 							text: null
 						}},
-
 						series: [{
 							name: '',
 							data: [#altitude#]
 						}]
-
 					});
 				}
 			</script>


### PR DESCRIPTION
- Position et visibilité des textes N E S W sur l'azimut du soleil. L'est était à la place du Nord. Le W opacity 0
- Idem pour 90 0 -90 sur l'altitude.
- Aiguille rouge et pivot argent pour plus de visibilité quel que soit le thème.
- Réduction de l'encombrement des textes des heures de lever et coucher du soleil et des icones qui empêchait le survol des aiguilles et l'apparition des tooltip.
- Augmentation de la taille des icones soleil et lune ( fa-2x )

- Remontée sur la template de plus infos: aubeciv, crepciv, aubenau, crepnau, aubeast, crepast, zenith, daylen
- Prévention d'erreur 500 Si lors de la 1ère sauvegarde il y a des erreurs ( toutes les cmds ne sont pas créées, l'équipement ne peut plus ensuite être sauvegardé ( erreur 500 ).
- Correction de zenith. Dans le calcul avec les fonctions date_sunrise et date_sunset les valeurs utilisées pour le paramètre zénith étaient 90.58, 96.58, 102.58 et 108.58  Sur la doc des fonctions php https://www.php.net/manual/en/function.date-sunrise.php les valeurs pour le paramètre zenith sont 90°50', 96, 102 et 108. Pour la fonction php date_sun_info https://www.php.net/manual/en/function.date-sun-info.php les valeurs de zenith sont 90°35' qui correspond à 90.58°, 96, 102 et 108. J'ai utilisé 90.58, 96, 102 et 108
- Ajout de la possibilité d'utiliser une template _user. Si un fichier heliotrope_user.html existe, il sera utilisé plutôt que le fichier heliotrope.html. Le fichier heliotrope_user.html n'est pas fourni avec le plugin. Cela permet de conserver une template modifiée malgré les mises à jour du plugin.
- Remplacement des log::add('heliotrope' par log::add(__CLASS__ pour améliorer la portabilité du code d'un plugin à l'autre.