### PR TITLE
Correction test si localisation initialisée dans Jeedom

### DIFF
--- a/desktop/php/heliotrope.php
+++ b/desktop/php/heliotrope.php
@@ -130,7 +130,7 @@ $eqLogics = eqLogic::byType('heliotrope');
                                             }
                                         }
                                     } 
-                                    if ((config::byKey('info::latitude','core','0') != '0') && (config::byKey('info::longitude','core','0') != '0')) {
+                                    if ((config::byKey('info::latitude','core','91') != '91') && (config::byKey('info::longitude','core','361') != '361')) {
                                         echo '<option value="jeedom">Configuration Jeedom</option>';
                                         $none = 1;
                                     }


### PR DESCRIPTION
Je teste souvent avec latitude 45 et longitude 0.
Avec ces valeurs, Configuration Jeedom n'est pas proposé.
J'ai mis des valeurs impossibles pour tester si la localisation n'est pas configuré.